### PR TITLE
Bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const u256 = require('./lib/u256');
 
 const maxBlocks = 24;
+const maxTarget = 0x1e0fffff;
 
 function getDarkTarget(blocks) {
   const start = new u256();
@@ -24,6 +25,8 @@ function getDarkTarget(blocks) {
 * original work done by evan duffield, modified for javascript
 */
 const getTarget = function getTarget(allHeaders, blockTime = 150) {
+  if (allHeaders.length < maxBlocks) return maxTarget;
+
   const blocks = allHeaders.slice(Math.max(allHeaders.length - maxBlocks, 0)).reverse();
 
   const timeSpanTarget = (blocks.length) * blockTime;
@@ -38,10 +41,10 @@ const getTarget = function getTarget(allHeaders, blockTime = 150) {
     .getCompact();
 
   // Prevent too high target (ie too low difficulty)
-  const maxTarget =
-    (darkTarget >>> 1) > 0xF07FFF8 ? 0x1e0ffff0 : darkTarget; // eslint-disable-line no-bitwise
+  // eslint-disable-next-line no-bitwise
+  const target = (darkTarget >>> 1) > 0xF07FFF8 ? maxTarget : darkTarget;
 
-  return maxTarget;
+  return target;
 };
 
 module.exports = {


### PR DESCRIPTION
Seems like the original DGW V3 port from c++ to js had a bug on the maxtarget defined as` 0x1e0ffff0`:
https://github.com/dashpay/dark-gravity-wave-js/blob/2178956cd63610dd4a0d12948f0326c28125a085/index.js#L73

Here is the reference to the dashcore c++ code showing maxtarget shoud be `0x1e0fffff`:
https://github.com/dashevo/dash/blob/542efa3ab90c0daefb7e15b0428356f22bb6f96c/src/chainparams.cpp#L143 (note that dash core target is in extended format not compact as stored in blocks)

Updating this makes the tests in `spv-dash` pass which are now based on the first 26 testnet headers
