### PR TITLE
Fix allow min difficulty blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @dashevo/dark-gravity-wave
 ## Usage
 
 ```js
-var dgw = require('@dashevo/dark-gravity-wave');
+const dgw = require('@dashevo/dark-gravity-wave');
 
 dgw.hasValidTarget(header, previousHeaders, 'testnet');
 // -> true or false
@@ -22,11 +22,19 @@ dgw.hasValidTarget(header, previousHeaders, 'testnet');
 
 ## API
 
-### hasValidTarget(header, previousHeaders, [network = 'mainnet])
+### hasValidTarget(header, previousHeaders, [network = 'mainnet'])
 
-#### array
+#### header
+
+Type: `object`
+
+#### previousHeaders
 
 Type: `array`
+
+#### network
+
+Type: `string` (optional, default = 'mainnet')
 
 Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain the last 24 blocks. Arrays with length > 24 are allowed however only latest 24 will be considered.
 The block header objects must contain *timestamp* and *target* properties (nBits field in the block header)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Type: `array`
 
 Type: `string` (optional, default = 'mainnet')
 
-Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain the last 24 blocks. Arrays with length > 24 are allowed however only latest 24 will be considered.
+Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain the last 24 blocks. Arrays with length > 24 are allowed however only the latest 24 will be considered.
 The block header objects must contain *timestamp* and *target* properties (nBits field in the block header)
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Type: `array`
 
 Type: `string` (optional, default = 'mainnet')
 
-Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain the last 24 blocks. Arrays with length > 24 are allowed however only the latest 24 will be considered.
+Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain block header objects of the last 24 blocks. Arrays with length > 24 are allowed however only the latest 24 will be considered.
 The block header objects must contain *timestamp* and *target* properties (nBits field of the block header)
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Type: `array`
 Type: `string` (optional, default = 'mainnet')
 
 Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain the last 24 blocks. Arrays with length > 24 are allowed however only the latest 24 will be considered.
-The block header objects must contain *timestamp* and *target* properties (nBits field in the block header)
+The block header objects must contain *timestamp* and *target* properties (nBits field of the block header)
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/dashevo/dark-gravity-wave-js.svg?branch=master)](https://travis-ci.com/dashevo/dark-gravity-wave-js)
 [![NPM version](https://img.shields.io/npm/v/@dashevo/dark-gravity-wave.svg)](https://npmjs.org/package/@dashevo/dark-gravity-wave)
 
-> Dark Gravity Wave difficulty retarget algorithm in JavaScript
+> Dark Gravity Wave difficulty retargeting algorithm in JavaScript
 
 ## Install
 
@@ -16,28 +16,21 @@ npm install @dashevo/dark-gravity-wave
 ```js
 var dgw = require('@dashevo/dark-gravity-wave');
 
-dgw.getTarget(lastHeaders);
-// -> '1be4c4d3'
+dgw.hasValidTarget(header, previousHeaders, 'testnet');
+// -> true or false
 ```
 
 ## API
 
-### getTarget(array)
+### hasValidTarget(header, previousHeaders, [network = 'mainnet])
 
 #### array
 
 Type: `array`
 
-Get the difficulty.  The array must contain the last 24 blocks. Arrays with length > 24 are allowed however only latest 24 will be considered.
-Array objects must contain *timestamp* and *target* properties (where target = the difficulty at which the block has been solved)
+Validates the target (bits) property of a block header. The 2nd argument, the array of most recent previous headers, must contain the last 24 blocks. Arrays with length > 24 are allowed however only latest 24 will be considered.
+The block header objects must contain *timestamp* and *target* properties (nBits field in the block header)
 
-### getTarget(array,blockTime)
-
-#### array
-
-Type: `array`, `int` (default 150)
-
-Get the difficulty for dark-gravity-wave's other than dash's 150 second block time.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -53,17 +53,21 @@ function getTarget(allHeaders, newHeader, network = 'mainnet') {
   const blocks = allHeaders.slice(Math.max(allHeaders.length - maxBlocks, 0)).reverse();
 
   if (allowMinDifficultyBlocks) {
-    // recent block is more than 2 hours old
+    // most recent block is more than 2 hours old
     if (newHeader.timestamp > blocks[0].timestamp + (2 * 60 * 60)) {
       return maxTarget;
     }
-    // recent block is more than 10 minutes old
+    // most recent block is more than 10 minutes old
     if (newHeader.timestamp > blocks[0].timestamp + (powTargetSpacing * 4)) {
-      let bnNew = blocks[0].target * 10;
-      if (bnNew > maxTarget) {
-        bnNew = maxTarget;
+      let bnNew = new u256();
+      bnNew.setCompact(blocks[0].target);
+      bnNew = bnNew.multiplyWithInteger(10);
+      const uMaxTarget = new u256();
+      uMaxTarget.setCompact(maxTarget);
+      if (bnNew.getCompact() > uMaxTarget.getCompact()) {
+        bnNew = uMaxTarget;
       }
-      return bnNew;
+      return bnNew.getCompact();
     }
   }
   // nTargetTimespan is the time that the blocks should have taken to be generated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dark-gravity-wave",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -797,9 +797,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
+      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==",
       "dev": true
     },
     "core-util-is": {
@@ -3167,9 +3167,9 @@
       }
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
-      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dark-gravity-wave",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Dark Gravity Wave difficulty retarget algorithm in JavaScript",
   "main": "index.js",
   "scripts": {

--- a/test/dark-gravity-wave-test.js
+++ b/test/dark-gravity-wave-test.js
@@ -466,20 +466,20 @@ describe('dark gravity wave', () => {
       expect(result).to.equal(false);
     });
 
-    it('should have lowest diff with timestamp (10m+1sec)', () => {
+    it('should have target below lowest target with timestamp (10m+1sec)', () => {
       timestamp = 1438531999 + 601;
       const highTargetBits = 0x207fffff;
       const header = { target: highTargetBits, timestamp };
       const result = dgw.hasValidTarget(header, blocks, 'devnet');
-      expect(result).to.equal(true);
+      expect(result).to.equal(false);
     });
 
-    it('should have lowest diff with timestamp (20m)', () => {
+    it('should have target below lowest target with timestamp (20m)', () => {
       timestamp = 1438531999 + 1200;
       const highTargetBits = 0x207fffff;
       const header = { target: highTargetBits, timestamp };
       const result = dgw.hasValidTarget(header, blocks, 'devnet');
-      expect(result).to.equal(true);
+      expect(result).to.equal(false);
     });
 
     it('should have lowest diff with timestamp (2h+1sec)', () => {

--- a/test/dark-gravity-wave-test.js
+++ b/test/dark-gravity-wave-test.js
@@ -466,7 +466,7 @@ describe('dark gravity wave', () => {
       expect(result).to.equal(false);
     });
 
-    it('should have target below lowest target with timestamp (10m+1sec)', () => {
+    it('should have target below max target with timestamp (10m+1sec)', () => {
       timestamp = 1438531999 + 601;
       const highTargetBits = 0x207fffff;
       const header = { target: highTargetBits, timestamp };
@@ -474,7 +474,7 @@ describe('dark gravity wave', () => {
       expect(result).to.equal(false);
     });
 
-    it('should have target below lowest target with timestamp (20m)', () => {
+    it('should have target below max target with timestamp (20m)', () => {
       timestamp = 1438531999 + 1200;
       const highTargetBits = 0x207fffff;
       const header = { target: highTargetBits, timestamp };


### PR DESCRIPTION
When writing testnet test cases for dash-spv I realised that there was a bug in the `allowMinDifficultyBlocks` section. The calculations have to be made with the u256 primitive and not with the compact integer. Only with this change can dash-spv validate correctly for testnet.

Also updated readme.